### PR TITLE
new api to get range ids from unixtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ ok
 1509193995927
 
 > esnowflake:stats().
-[{version,"0.3.0"},
+[{version, undefined},
  {worker_num,10},
  {worker_ids,[0,1,2,3,4,5,6,7,8,9]}]
+
+1> {Start, End} = {os:system_time(seconds)-3600*24, os:system_time(seconds)}.
+{1528600349,1528686749}
+2> esnowflake:range_ids(Start,End).
+[2900661259315707904,2900661621707767807]
+
 ```
 
 Config

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This must be specified as not to duplicate worker ids if you use multi nodes.
 params            | default | explain
 ----------------- | ------- | ---------------------------------------------------------
 worker_num        | 2       | number of generate id workers
-worker_min_max_id | [0, 9]  | worker ids
+worker_min_max_id | [0, 1]  | worker ids
 redis             | -       | eredis config for assigning worker ids automatically
 
 

--- a/include/esnowflake.hrl
+++ b/include/esnowflake.hrl
@@ -1,5 +1,5 @@
 -define(TWEPOCH, 1508980320000). %% 2017-10-26 01:12:00 (UTC)
--define(DEFAULT_WORKER_MIN_MAX, [0, 9]).
--define(DEFAULT_WORKER_NUM, 10).
+-define(DEFAULT_WORKER_MIN_MAX, [0, 1]).
+-define(DEFAULT_WORKER_NUM, 2).
 -define(WORKER_ID_RANGE, 1024).
 -define(ETS_WORKER, esnowflake_workers).

--- a/src/esnowflake.erl
+++ b/src/esnowflake.erl
@@ -11,6 +11,8 @@
          to_unixtime/2,
          unixtime_to_id/1,
          unixtime_to_id/2,
+         range_ids/2,
+         range_ids/3,
          decode_id/1,
          stats/0]).
 
@@ -71,6 +73,24 @@ unixtime_to_id(UnixTime, milli_seconds) ->
     TS = UnixTime - ?TWEPOCH,
     <<Id:64>> = <<0:1, TS:41, 0:22>>,
     Id.
+
+%% @doc
+%% Returns minimum and maximum ids from unixtime.
+%% This range expresses `min <= x < max`.
+%% @end
+-spec range_ids(StartTime :: integer(), EndTime :: integer()) -> [integer()].
+range_ids(StartTime, EndTime) ->
+    range_ids(StartTime, EndTime, milli_seconds).
+
+%% @doc
+%% Returns minimum and maximum ids from unixtime with time_unit().
+%% This range expresses `min <= x <= max`.
+%% @end
+-spec range_ids(StartTime :: integer(), EndTime :: integer(), time_unit()) -> [integer()].
+range_ids(StartTime, EndTime, seconds) ->
+    [unixtime_to_id(StartTime*1000), unixtime_to_id(EndTime*1000+1)-1];
+range_ids(StartTime, EndTime, milli_seconds) ->
+    [unixtime_to_id(StartTime), unixtime_to_id(EndTime + 1)-1].
 
 %% @doc
 %% Decode generated id to unix time, machine id and sequential number.

--- a/test/esnowflake_SUITE.erl
+++ b/test/esnowflake_SUITE.erl
@@ -30,6 +30,7 @@
          t_stats/1,
          t_not_use_redis/1,
          t_over_worker_ids_limit/1,
+         t_range_ids/1,
          b_generate_id/1,
          b_generate_ids/1
         ]).
@@ -54,7 +55,8 @@ groups() ->
         t_unixtime_to_id,
         t_decode_id,
         t_not_use_redis,
-        t_over_worker_ids_limit]},
+        t_over_worker_ids_limit,
+        t_range_ids]},
 
      {bench, [], [
         b_generate_id,
@@ -187,6 +189,20 @@ t_over_worker_ids_limit(Config) ->
      {worker_ids, IDs}] = esnowflake:stats(),
 
     ?assert(length(IDs) =:= 1024),
+
+    Config.
+
+t_range_ids(Config) ->
+    % timestamp: Thu Dec 14 22:27:08 JST 2017
+    StartTime = 1513258028697,
+    StartTimeSec = 1513258028,
+
+    % timestamp: Thu Dec 21 22:27:08 JST 2017
+    EndTime = 1513862828697,
+    EndTimeSec = 1513862828,
+
+    [17942010698661888, 20478725762056191] = esnowflake:range_ids(StartTime, EndTime),
+    [17942007775232000, 20478722838626303] = esnowflake:range_ids(StartTimeSec, EndTimeSec, seconds),
 
     Config.
 


### PR DESCRIPTION
`range_ids/2` `range_ids/3` returns snowflake range ids from start and end unixtime.
This api is useful in case to want to refine your search by a date range.