### PR TITLE
use eredis version 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
     - _build
 
 before_script:
+  - git clone https://github.com/erlang/rebar3.git; cd rebar3; ./bootstrap; sudo mv rebar3 /usr/local/bin/; cd -
   - git clone https://github.com/inaka/elvis
   - cd elvis
   - rebar3 escriptize

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: erlang
 otp_release:
-  - 19.0
   - 20.0
   - 20.1.3
+  - 21.2
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@ dialyzer:
 	rebar3 dialyzer
 
 start-redis:
-	docker run -d --rm --name esnowflake_redis -p 26379:6379 redis:4
+	if [ "$(shell docker ps -q -f=name=esnowflake_redis)" = "" ] ; then \
+		docker run -d --rm --name esnowflake_redis -p 26379:6379 redis:4; \
+	fi
 
 stop-redis:
 	docker stop esnowflake_redis
 
 test: elvis dialyzer
+	$(MAKE) start-redis
 	rebar3 ct -v --config ./config/test.config --dir test --suite esnowflake_SUITE --group test
+	$(MAKE) stop-redis

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {erl_opts, [debug_info]}.
-{deps, [{eredis, "1.1.0"}]}.
+{deps, [{eredis, "1.2.0"}]}.
 {ct_opts, [{keep_logs, 1},
            {sys_config, "./config/test.config"}]}.

--- a/src/esnowflake.app.src
+++ b/src/esnowflake.app.src
@@ -1,6 +1,6 @@
 {application, esnowflake,
  [{description, "Twitter's Snowflake UUID generator in Erlang"},
-  {vsn, "0.4.1"},
+  {vsn, "0.4.2"},
   {registered, []},
   {mod, { esnowflake_app, []}},
   {applications,

--- a/src/esnowflake_worker.erl
+++ b/src/esnowflake_worker.erl
@@ -190,8 +190,8 @@ code_change(_OldVsn, State, _Extra) ->
 %% generate 64bit snowflake id
 %% @end
 -spec snowflake_id(Now :: integer(), State :: worker_state()) ->
-    integer() |
-    {error, err_clock_backwards, term(), worker_state()}.
+    {integer(), worker_state()} |
+    {error, term(), term(), worker_state()}.
 snowflake_id(Now, State = #state{pre_timestamp = PreTS}) when Now < PreTS ->
     Msg = io_lib:format("timestamp diff: ~p", [PreTS - Now]),
     {error, err_clock_backwards, Msg, State};
@@ -210,7 +210,7 @@ snowflake_id(Now, State = #state{worker_id = Wid}) ->
 %% generate 64bit snowflake ids
 %% @end
 -spec snowflake_ids(Now :: integer(), Num :: integer(), State :: worker_state()) ->
-    [integer()] |
+    {[integer()], worker_state()} |
     {error, err_clock_backwards, term(), worker_state()}.
 snowflake_ids(Now, Num, State) ->
     snowflake_ids(Now, Num, [], State).


### PR DESCRIPTION
- use eredis v1.2.0.
- `snowflake_id/2` and `snowflake_ids/3` specs were wrong, so fix.
- vsn update 0.4.1 -> 0.4.2.
- checks OTP 21.2 on travis ci 